### PR TITLE
usability improvements for CPU-only mode

### DIFF
--- a/skymagic.py
+++ b/skymagic.py
@@ -47,7 +47,8 @@ class SkyFilter():
     def load_model(self):
 
         print('loading the best checkpoint...')
-        checkpoint = torch.load(os.path.join(self.ckptdir, 'best_ckpt.pt'))
+        checkpoint = torch.load(os.path.join(self.ckptdir, 'best_ckpt.pt'),
+                                map_location=None if torch.cuda.is_available() else device)
         # checkpoint = torch.load(os.path.join(self.ckptdir, 'last_ckpt.pt'))
         self.net_G.load_state_dict(checkpoint['model_G_state_dict'])
         self.net_G.to(device)

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,10 @@ import glob
 import random
 
 import torch
-torch.cuda.current_device()
+
+if torch.cuda.is_available():
+    torch.cuda.current_device()
+
 import torchvision.transforms.functional as TF
 from torch.utils.data import Dataset, DataLoader, Subset
 from torchvision import transforms, utils


### PR DESCRIPTION
- added checking for GPU before calling `current_device()`
- on CPU-only mode, now maps storage location to CPU device when loading model due to the following error:

```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```