### PR TITLE
Fixes #22

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import cv2
-from skimage.measure import compare_ssim as sk_cpt_ssim
+from skimage.metrics import structural_similarity as sk_cpt_ssim
 
 import os
 import glob


### PR DESCRIPTION
Change compare_ssim to structural_similarity in the import. In Version 0.16 of scikit-learn the names was changed.
reference: https://scikit-image.org/docs/stable/api_changes.html